### PR TITLE
integrate frontend/dockerfile/dockerignore from BuildKit

### DIFF
--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -1,4 +1,4 @@
-package dockerignore
+package dockerignore // import "github.com/docker/docker/builder/dockerignore"
 
 import (
 	"bufio"

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -38,8 +38,23 @@ func ReadAll(reader io.Reader) ([]string, error) {
 		if pattern == "" {
 			continue
 		}
-		pattern = filepath.Clean(pattern)
-		pattern = filepath.ToSlash(pattern)
+		// normalize absolute paths to paths relative to the context
+		// (taking care of '!' prefix)
+		invert := pattern[0] == '!'
+		if invert {
+			pattern = strings.TrimSpace(pattern[1:])
+		}
+		if len(pattern) > 0 {
+			pattern = filepath.Clean(pattern)
+			pattern = filepath.ToSlash(pattern)
+			if len(pattern) > 1 && pattern[0] == '/' {
+				pattern = pattern[1:]
+			}
+		}
+		if invert {
+			pattern = "!" + pattern
+		}
+
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -3,10 +3,11 @@ package dockerignore
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ReadAll reads a .dockerignore file and returns the list of file patterns
@@ -58,7 +59,7 @@ func ReadAll(reader io.Reader) ([]string, error) {
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Error reading .dockerignore: %v", err)
+		return nil, errors.Wrap(err, "error reading .dockerignore")
 	}
 	return excludes, nil
 }

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -12,11 +12,11 @@ import (
 // ReadAll reads a .dockerignore file and returns the list of file patterns
 // to ignore. Note this will trim whitespace from each line as well
 // as use GO's "clean" func to get the shortest/cleanest path for each.
-func ReadAll(reader io.ReadCloser) ([]string, error) {
+func ReadAll(reader io.Reader) ([]string, error) {
 	if reader == nil {
 		return nil, nil
 	}
-	defer reader.Close()
+
 	scanner := bufio.NewScanner(reader)
 	var excludes []string
 	currentLine := 0

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -1,0 +1,34 @@
+package dockerignore
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// ReadAll reads a .dockerignore file and returns the list of file patterns
+// to ignore. Note this will trim whitespace from each line as well
+// as use GO's "clean" func to get the shortest/cleanest path for each.
+func ReadAll(reader io.ReadCloser) ([]string, error) {
+	if reader == nil {
+		return nil, nil
+	}
+	defer reader.Close()
+	scanner := bufio.NewScanner(reader)
+	var excludes []string
+
+	for scanner.Scan() {
+		pattern := strings.TrimSpace(scanner.Text())
+		if pattern == "" {
+			continue
+		}
+		pattern = filepath.Clean(pattern)
+		excludes = append(excludes, pattern)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("Error reading .dockerignore: %v", err)
+	}
+	return excludes, nil
+}

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -1,4 +1,4 @@
-package dockerignore // import "github.com/docker/docker/builder/dockerignore"
+package dockerignore
 
 import (
 	"bufio"

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -25,6 +25,7 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 			continue
 		}
 		pattern = filepath.Clean(pattern)
+		pattern = filepath.ToSlash(pattern)
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -20,7 +20,12 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 	var excludes []string
 
 	for scanner.Scan() {
-		pattern := strings.TrimSpace(scanner.Text())
+		// Lines starting with # (comments) are ignored before processing
+		pattern := scanner.Text()
+		if strings.HasPrefix(pattern, "#") {
+			continue
+		}
+		pattern = strings.TrimSpace(pattern)
 		if pattern == "" {
 			continue
 		}

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -2,6 +2,7 @@ package dockerignore
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -18,10 +19,18 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 	defer reader.Close()
 	scanner := bufio.NewScanner(reader)
 	var excludes []string
+	currentLine := 0
 
+	utf8bom := []byte{0xEF, 0xBB, 0xBF}
 	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		// We trim UTF8 BOM
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		pattern := string(scannedBytes)
+		currentLine++
 		// Lines starting with # (comments) are ignored before processing
-		pattern := scanner.Text()
 		if strings.HasPrefix(pattern, "#") {
 			continue
 		}

--- a/ignorefile/ignorefile.go
+++ b/ignorefile/ignorefile.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ReadAll reads an ignore file from a reader and returns the list of file
@@ -69,7 +67,7 @@ func ReadAll(reader io.Reader) ([]string, error) {
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, errors.Wrap(err, "error reading .dockerignore")
+		return nil, err
 	}
 	return excludes, nil
 }

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -1,0 +1,55 @@
+package dockerignore
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadAll(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "dockerignore-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	di, err := ReadAll(nil)
+	if err != nil {
+		t.Fatalf("Expected not to have error, got %v", err)
+	}
+
+	if diLen := len(di); diLen != 0 {
+		t.Fatalf("Expected to have zero dockerignore entry, got %d", diLen)
+	}
+
+	diName := filepath.Join(tmpDir, ".dockerignore")
+	content := fmt.Sprintf("test1\n/test2\n/a/file/here\n\nlastfile")
+	err = ioutil.WriteFile(diName, []byte(content), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diFd, err := os.Open(diName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	di, err = ReadAll(diFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if di[0] != "test1" {
+		t.Fatalf("First element is not test1")
+	}
+	if di[1] != "/test2" {
+		t.Fatalf("Second element is not /test2")
+	}
+	if di[2] != "/a/file/here" {
+		t.Fatalf("Third element is not /a/file/here")
+	}
+	if di[3] != "lastfile" {
+		t.Fatalf("Fourth element is not lastfile")
+	}
+}

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -43,7 +43,7 @@ func TestReadAll(t *testing.T) {
 	}
 
 	if len(di) != 7 {
-		t.Fatalf("Expected 5 entries, got %v", len(di))
+		t.Fatalf("Expected 7 entries, got %v", len(di))
 	}
 	if di[0] != "test1" {
 		t.Fatal("First element is not test1")
@@ -64,6 +64,6 @@ func TestReadAll(t *testing.T) {
 		t.Fatalf("Sixth element is not !, but %s", di[5])
 	}
 	if di[6] != "!" {
-		t.Fatalf("Sixth element is not !, but %s", di[6])
+		t.Fatalf("Seventh element is not !, but %s", di[6])
 	}
 }

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -1,4 +1,4 @@
-package dockerignore
+package dockerignore // import "github.com/docker/docker/builder/dockerignore"
 
 import (
 	"fmt"

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -1,4 +1,4 @@
-package dockerignore // import "github.com/docker/docker/builder/dockerignore"
+package dockerignore
 
 import (
 	"fmt"

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -25,7 +25,7 @@ func TestReadAll(t *testing.T) {
 	}
 
 	diName := filepath.Join(tmpDir, ".dockerignore")
-	content := fmt.Sprintf("test1\n/test2\n/a/file/here\n\nlastfile")
+	content := fmt.Sprintf("test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n")
 	err = ioutil.WriteFile(diName, []byte(content), 0777)
 	if err != nil {
 		t.Fatal(err)
@@ -42,16 +42,28 @@ func TestReadAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if len(di) != 7 {
+		t.Fatalf("Expected 5 entries, got %v", len(di))
+	}
 	if di[0] != "test1" {
 		t.Fatal("First element is not test1")
 	}
-	if di[1] != "/test2" {
-		t.Fatal("Second element is not /test2")
+	if di[1] != "test2" { // according to https://docs.docker.com/engine/reference/builder/#dockerignore-file, /foo/bar should be treated as foo/bar
+		t.Fatal("Second element is not test2")
 	}
-	if di[2] != "/a/file/here" {
-		t.Fatal("Third element is not /a/file/here")
+	if di[2] != "a/file/here" { // according to https://docs.docker.com/engine/reference/builder/#dockerignore-file, /foo/bar should be treated as foo/bar
+		t.Fatal("Third element is not a/file/here")
 	}
 	if di[3] != "lastfile" {
 		t.Fatal("Fourth element is not lastfile")
+	}
+	if di[4] != "!inverted/abs/path" {
+		t.Fatal("Fifth element is not !inverted/abs/path")
+	}
+	if di[5] != "!" {
+		t.Fatalf("Sixth element is not !, but %s", di[5])
+	}
+	if di[6] != "!" {
+		t.Fatalf("Sixth element is not !, but %s", di[6])
 	}
 }

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -35,6 +35,8 @@ func TestReadAll(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer diFd.Close()
+
 	di, err = ReadAll(diFd)
 	if err != nil {
 		t.Fatal(err)

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -43,15 +43,15 @@ func TestReadAll(t *testing.T) {
 	}
 
 	if di[0] != "test1" {
-		t.Fatalf("First element is not test1")
+		t.Fatal("First element is not test1")
 	}
 	if di[1] != "/test2" {
-		t.Fatalf("Second element is not /test2")
+		t.Fatal("Second element is not /test2")
 	}
 	if di[2] != "/a/file/here" {
-		t.Fatalf("Third element is not /a/file/here")
+		t.Fatal("Third element is not /a/file/here")
 	}
 	if di[3] != "lastfile" {
-		t.Fatalf("Fourth element is not lastfile")
+		t.Fatal("Fourth element is not lastfile")
 	}
 }

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -2,14 +2,13 @@ package dockerignore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestReadAll(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "dockerignore-test")
+	tmpDir, err := os.MkdirTemp("", "dockerignore-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +25,7 @@ func TestReadAll(t *testing.T) {
 
 	diName := filepath.Join(tmpDir, ".dockerignore")
 	content := fmt.Sprintf("test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n")
-	err = ioutil.WriteFile(diName, []byte(content), 0777)
+	err = os.WriteFile(diName, []byte(content), 0777)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -7,12 +7,6 @@ import (
 )
 
 func TestReadAll(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "dockerignore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
 	di, err := ReadAll(nil)
 	if err != nil {
 		t.Fatalf("Expected not to have error, got %v", err)
@@ -22,7 +16,7 @@ func TestReadAll(t *testing.T) {
 		t.Fatalf("Expected to have zero dockerignore entry, got %d", diLen)
 	}
 
-	diName := filepath.Join(tmpDir, ".dockerignore")
+	diName := filepath.Join(t.TempDir(), ".dockerignore")
 	content := "test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n"
 	err = os.WriteFile(diName, []byte(content), 0777)
 	if err != nil {

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -1,7 +1,6 @@
 package dockerignore
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ func TestReadAll(t *testing.T) {
 	}
 
 	diName := filepath.Join(tmpDir, ".dockerignore")
-	content := fmt.Sprintf("test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n")
+	content := "test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n"
 	err = os.WriteFile(diName, []byte(content), 0777)
 	if err != nil {
 		t.Fatal(err)

--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -18,7 +18,7 @@ func TestReadAll(t *testing.T) {
 
 	diName := filepath.Join(t.TempDir(), ".dockerignore")
 	content := "test1\n/test2\n/a/file/here\n\nlastfile\n# this is a comment\n! /inverted/abs/path\n!\n! \n"
-	err = os.WriteFile(diName, []byte(content), 0777)
+	err = os.WriteFile(diName, []byte(content), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/buildkit/pull/4062
- relates to https://github.com/docker/cli/pull/4457


Integrating the "frontend/dockerfile/dockerignore" package from
github.com/moby/buildkit at commit https://github.com/moby/buildkit/commit/9da03ce42beb47d0d0a34c68ea90cac793b79851

Steps taken:

```bash
# install filter-repo (https://github.com/newren/git-filter-repo/blob/main/INSTALL.md)
brew install git-filter-repo

# create a temporary clone of docker
cd ~/Projects
git clone https://github.com/moby/buildkit.git buildkit_temp
cd buildkit_temp

# commit taken from
git rev-parse --verify HEAD
9da03ce42beb47d0d0a34c68ea90cac793b79851

# remove all code, except for 'frontend/dockerfile/dockerignore', and rename to /ignorefile
git filter-repo \
  --path-match 'frontend/dockerfile/dockerignore/' \
  --path-rename frontend/dockerfile/dockerignore/dockerignore.go:ignorefile/ignorefile.go \
  --path-rename frontend/dockerfile/dockerignore/dockerignore_test.go:ignorefile/ignorefile_test.go

# go to the target github.com/moby/patternmatcher repository
cd ~/go/src/github.com/moby/patternmatcher

# create a branch to work with
git checkout -b integrate_dockerignore

# add the temporary repository as an upstream and make sure it's up-to-date
git remote add buildkit_temp ~/Projects/buildkit_temp
git fetch buildkit_temp

# merge the upstream code
git merge --allow-unrelated-histories --signoff -S buildkit_temp/master
```
