### PR TITLE
Add ignorefile read all negative test case

### DIFF
--- a/ignorefile/ignorefile_test.go
+++ b/ignorefile/ignorefile_test.go
@@ -1,14 +1,31 @@
 package ignorefile
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
+
+type emitErrorOnRead struct{}
+
+var errRead = errors.New("read error")
+
+func (r emitErrorOnRead) Read(_ []byte) (int, error) {
+	return 0, errRead
+}
 
 func TestReadAll(t *testing.T) {
 	actual, err := ReadAll(nil)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
+	}
+	if entries := len(actual); entries != 0 {
+		t.Fatalf("Expected to have zero entries, got %d", entries)
+	}
+
+	actual, err = ReadAll(emitErrorOnRead{})
+	if !errors.Is(err, errRead) {
+		t.Fatalf("Expected %v, got %v", errRead, err)
 	}
 	if entries := len(actual); entries != 0 {
 		t.Fatalf("Expected to have zero entries, got %d", entries)


### PR DESCRIPTION
This change adds a negative test case to validate ignorefile read all returns errors from the passed in reader.