### PR TITLE
Update to golangci-lint@v1.60

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,5 +20,5 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53
+          version: v1.60
           args: --print-resources-usage --timeout=10m --verbose


### PR DESCRIPTION
This change updates to golangci-lint@v1.60 in CI